### PR TITLE
derive `Debug` for relations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,6 +436,7 @@ fn make_struct_decls(context: &Context) -> proc_macro2::TokenStream {
             let fields = &relation.fields;
             quote_spanned! {name.span()=>
                 #[derive(
+                    ::core::fmt::Debug,
                     ::core::marker::Copy,
                     ::core::clone::Clone,
                     ::core::cmp::Eq,

--- a/tests/test_destructure.rs
+++ b/tests/test_destructure.rs
@@ -2,7 +2,7 @@
 
 use crepe::crepe;
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 enum Token {
     String(&'static str),
     Integer(i32),

--- a/tests/ui/not_eq_relation.stderr
+++ b/tests/ui/not_eq_relation.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `f64: std::hash::Hash` is not satisfied
+error[E0277]: the trait bound `f64: Hash` is not satisfied
    --> $DIR/not_eq_relation.rs:8:15
     |
 8   |     struct Ok(f64);
-    |               ^^^ the trait `std::hash::Hash` is not implemented for `f64`
+    |               ^^^ the trait `Hash` is not implemented for `f64`
     |
    ::: $RUST/core/src/hash/mod.rs
     |
@@ -11,15 +11,15 @@ error[E0277]: the trait bound `f64: std::hash::Hash` is not satisfied
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `f64: std::cmp::Eq` is not satisfied
+error[E0277]: the trait bound `f64: Eq` is not satisfied
    --> $DIR/not_eq_relation.rs:8:15
     |
 8   |     struct Ok(f64);
-    |               ^^^ the trait `std::cmp::Eq` is not implemented for `f64`
+    |               ^^^ the trait `Eq` is not implemented for `f64`
     |
    ::: $RUST/core/src/cmp.rs
     |
     | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-    |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+    |                               -- required by this bound in `AssertParamIsEq`
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This commit makes all relations derive `Debug`. With a `Debug`
implementantion it's more comfortable debugging during development.