### PR TITLE
add shorter syntax for defining fact-rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ use strata::Strata;
 ///
 /// # Generated Code
 /// Each `struct` in the program is turned into a Datalog relation, while each
-/// line of the form `goal <- clause1, clause2, ...;` defines a logic
-/// programming rule that is used to derive new relations.
+/// line of the form `goal <- clause1, clause2, ...;` or `fact;` defines a
+/// logic programming rule that is used to derive new relations.
 ///
 /// In addition to the relation structs, the macro also defines a `Crepe`
 /// struct representing the runtime. This is the primary way that you interact
@@ -94,7 +94,7 @@ use strata::Strata;
 ///     struct Fib(u32, u32);
 ///
 ///     Fib(0, 0) <- (true);
-///     Fib(1, 1) <- (true);
+///     Fib(1, 1); // shorthand for `Fib(1, 1) <- (true);`
 ///
 ///     Fib(n + 2, x + y) <- Fib(n, x), Fib(n + 1, y), (n + 2 <= 25);
 /// }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -71,12 +71,31 @@ pub struct Rule {
 
 impl Parse for Rule {
     fn parse(input: ParseStream) -> Result<Self> {
-        Ok(Self {
-            goal: input.parse()?,
-            arrow_token: input.parse()?,
-            clauses: Punctuated::parse_separated_nonempty(input)?,
-            semi_token: input.parse()?,
-        })
+        let goal = input.parse()?;
+        let lookahead = input.lookahead1();
+
+        // A fact followed by a semicolon is the same as a rule with a single
+        // clause of `(true)`
+        if lookahead.peek(Token![;]) {
+            let semi_token = input.parse()?;
+
+            let arrow_token = syn::parse_quote!(<-);
+            let clauses = syn::parse_quote!((true));
+
+            Ok(Self {
+                goal,
+                arrow_token,
+                clauses,
+                semi_token,
+            })
+        } else {
+            Ok(Self {
+                goal,
+                arrow_token: input.parse()?,
+                clauses: Punctuated::parse_separated_nonempty(input)?,
+                semi_token: input.parse()?,
+            })
+        }
     }
 }
 

--- a/tests/test_fibonacci.rs
+++ b/tests/test_fibonacci.rs
@@ -11,8 +11,8 @@ mod datalog {
         @output
         struct Fib(u32, u32);
 
-        Fib(0, 0) <- (true);
-        Fib(1, 1) <- (true);
+        Fib(0, 0);
+        Fib(1, 1);
 
         Fib(n + 2, x + y) <- Fib(n, x), Fib(n + 1, y), (n <= 23);
     }

--- a/tests/test_negation.rs
+++ b/tests/test_negation.rs
@@ -4,7 +4,7 @@ use crepe::crepe;
 
 crepe! {
     struct R1(u32, u32);
-    R1(2, 3) <- (true);
+    R1(2, 3);
 
     struct Ok1();
     Ok1() <- R1(2, 3), !R1(2, 2);

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -23,6 +23,7 @@ mod datalog {
 
         Intermediate(_x, crepe, z) <- (true), (false), Intermediate(_x, crepe, z);
         Intermediate(42, y, 'c') <- (true), (false), Intermediate(_x, y, _z);
+        Intermediate(21, 85, 'q');
 
         @output
         struct Node(i32);

--- a/tests/ui/bad_goal_input.rs
+++ b/tests/ui/bad_goal_input.rs
@@ -8,7 +8,7 @@ mod datalog {
         @input
         struct In(u32, u32);
 
-        In(0, 0) <- (true);
+        In(0, 0);
     }
 }
 

--- a/tests/ui/bad_goal_input.stderr
+++ b/tests/ui/bad_goal_input.stderr
@@ -1,5 +1,5 @@
 error: Relations marked as @input cannot be derived from a rule.
   --> $DIR/bad_goal_input.rs:11:9
    |
-11 |         In(0, 0) <- (true);
+11 |         In(0, 0);
    |         ^^

--- a/tests/ui/invalid_arity.rs
+++ b/tests/ui/invalid_arity.rs
@@ -7,8 +7,8 @@ mod datalog {
         @output
         struct Fib(u32, u32);
 
-        Fib(0, 0, 2) <- (true);
-        Fib(1, 1) <- (true);
+        Fib(0, 0, 2);
+        Fib(1, 1);
     }
 }
 

--- a/tests/ui/invalid_arity.stderr
+++ b/tests/ui/invalid_arity.stderr
@@ -1,5 +1,5 @@
 error: Relation 'Fib' was declared with arity 2, but constructed with arity 3 here.
   --> $DIR/invalid_arity.rs:10:9
    |
-10 |         Fib(0, 0, 2) <- (true);
+10 |         Fib(0, 0, 2);
    |         ^^^

--- a/tests/ui/not_eq_relation.stderr
+++ b/tests/ui/not_eq_relation.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `f64: std::hash::Hash` is not satisfied
+error[E0277]: the trait bound `f64: Hash` is not satisfied
    --> $DIR/not_eq_relation.rs:8:15
     |
 8   |     struct Ok(f64);
-    |               ^^^ the trait `std::hash::Hash` is not implemented for `f64`
+    |               ^^^ the trait `Hash` is not implemented for `f64`
     |
    ::: $RUST/core/src/hash/mod.rs
     |
@@ -11,15 +11,15 @@ error[E0277]: the trait bound `f64: std::hash::Hash` is not satisfied
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `f64: std::cmp::Eq` is not satisfied
+error[E0277]: the trait bound `f64: Eq` is not satisfied
    --> $DIR/not_eq_relation.rs:8:15
     |
 8   |     struct Ok(f64);
-    |               ^^^ the trait `std::cmp::Eq` is not implemented for `f64`
+    |               ^^^ the trait `Eq` is not implemented for `f64`
     |
    ::: $RUST/core/src/cmp.rs
     |
     | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-    |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+    |                               -- required by this bound in `AssertParamIsEq`
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/unbound_variable.rs
+++ b/tests/ui/unbound_variable.rs
@@ -7,8 +7,8 @@ mod datalog {
         @output
         struct Fib(u32, u32);
 
-        Fib(0, 0) <- (true);
-        Fib(1, 1) <- (true);
+        Fib(0, 0);
+        Fib(1, 1);
 
         Fib(n, x + y) <- Fib(n - 1, x), Fib(n - 2, y), (n <= 25);
     }


### PR DESCRIPTION
Instead of writing `Fact(a, b) <- (true);` one can now write `Fact(a, b);`