### PR TITLE
add visibility modifiers to structs and fields, support struct attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,8 +393,8 @@ impl Index {
         self.mode
             .iter()
             .zip(rel.fields.iter())
-            .filter_map(|(mode, ty)| match mode {
-                IndexMode::Bound => Some(ty),
+            .filter_map(|(mode, field)| match mode {
+                IndexMode::Bound => Some(&field.ty),
                 IndexMode::Free => None,
             })
             .collect()
@@ -430,7 +430,9 @@ fn make_struct_decls(context: &Context) -> proc_macro2::TokenStream {
     context
         .all_relations()
         .map(|relation| {
+            let attrs = &relation.attrs;
             let struct_token = &relation.struct_token;
+            let vis = &relation.visibility;
             let name = &relation.name;
             let semi_token = &relation.semi_token;
             let fields = &relation.fields;
@@ -442,7 +444,8 @@ fn make_struct_decls(context: &Context) -> proc_macro2::TokenStream {
                     ::core::cmp::PartialEq,
                     ::core::hash::Hash,
                 )]
-                #struct_token #name(#fields)#semi_token
+                #(#attrs)*
+                #vis #struct_token #name(#fields)#semi_token
             }
         })
         .collect()

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,11 @@
 //! Parsing logic
 
-use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{parenthesized, token, Expr, ExprLet, Ident, Result, Token, Type};
+use syn::{parenthesized, token, Attribute, Expr, ExprLet, Ident, Result, Token, Visibility};
+use syn::{
+    parse::{Parse, ParseStream},
+    Field,
+};
 
 #[derive(Clone)]
 pub struct Program {
@@ -33,10 +36,12 @@ impl Parse for Program {
 #[derive(Clone)]
 pub struct Relation {
     pub attribute: Option<Ident>,
+    pub attrs: Vec<Attribute>,
+    pub visibility: Visibility,
     pub struct_token: Token![struct],
     pub name: Ident,
     pub paren_token: token::Paren,
-    pub fields: Punctuated<Type, Token![,]>,
+    pub fields: Punctuated<Field, Token![,]>,
     pub semi_token: Token![;],
 }
 
@@ -52,10 +57,12 @@ impl Parse for Relation {
         #[allow(clippy::eval_order_dependence)]
         Ok(Self {
             attribute,
+            attrs: input.call(Attribute::parse_outer)?,
+            visibility: input.parse()?,
             struct_token: input.parse()?,
             name: input.parse()?,
             paren_token: parenthesized!(content in input),
-            fields: content.parse_terminated(Type::parse)?,
+            fields: content.parse_terminated(Field::parse_unnamed)?,
             semi_token: input.parse()?,
         })
     }

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -8,7 +8,8 @@ mod datalog {
 
     crepe! {
         @input
-        struct Edge(i32, i32);
+        #[derive(Debug)]
+        pub(crate) struct Edge(pub i32, pub i32);
 
         @output
         struct Tc(i32, i32);

--- a/tests/test_structs.rs
+++ b/tests/test_structs.rs
@@ -10,13 +10,14 @@ mod datalog {
         struct Edge(i32, i32);
 
         @output
-        struct Tc(i32, i32);
+        pub struct Tc(pub i32, pub i32);
 
         Tc(x, y) <- Edge(x, y);
         Tc(x, z) <- Edge(x, y), Tc(y, z);
     }
 
     pub fn run(_edges: &[(i32, i32)]) -> Vec<(i32, i32)> {
+        // accessible here in the same module
         let _ = (Edge(2, 3), Tc(2, 3));
         vec![]
     }
@@ -25,4 +26,6 @@ mod datalog {
 #[test]
 fn test_declare_structs() {
     assert_eq!(datalog::run(&[]), vec![]);
+    // check that the Tc struct and its fields are public
+    let _ = datalog::Tc(2, 3);
 }

--- a/tests/ui/bad_visibility_of_relation.rs
+++ b/tests/ui/bad_visibility_of_relation.rs
@@ -1,0 +1,23 @@
+// In this test the visibility modifiers of relation structs and their fields
+// are checked to be translated into the final Rust code properly.
+
+mod datalog {
+    use crepe::crepe;
+
+    crepe! {
+        @input
+        struct Test(u32);
+
+        @input
+        pub struct MoreTest(bool);
+
+        @input
+        pub struct FullyPublic(pub i8);
+    }
+}
+
+fn main() {
+    let _ = datalog::FullyPublic(21);
+    let _ = datalog::Test(1);
+    let _ = datalog::MoreTest(false);
+}

--- a/tests/ui/bad_visibility_of_relation.stderr
+++ b/tests/ui/bad_visibility_of_relation.stderr
@@ -1,0 +1,29 @@
+error[E0603]: tuple struct constructor `Test` is private
+  --> $DIR/bad_visibility_of_relation.rs:21:22
+   |
+9  |         struct Test(u32);
+   |                     --- a constructor is private if any of the fields is private
+...
+21 |     let _ = datalog::Test(1);
+   |                      ^^^^ private tuple struct constructor
+   |
+note: the tuple struct constructor `Test` is defined here
+  --> $DIR/bad_visibility_of_relation.rs:9:9
+   |
+9  |         struct Test(u32);
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0603]: tuple struct constructor `MoreTest` is private
+  --> $DIR/bad_visibility_of_relation.rs:22:22
+   |
+12 |         pub struct MoreTest(bool);
+   |                             ---- a constructor is private if any of the fields is private
+...
+22 |     let _ = datalog::MoreTest(false);
+   |                      ^^^^^^^^ private tuple struct constructor
+   |
+note: the tuple struct constructor `MoreTest` is defined here
+  --> $DIR/bad_visibility_of_relation.rs:12:9
+   |
+12 |         pub struct MoreTest(bool);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/not_eq_relation.stderr
+++ b/tests/ui/not_eq_relation.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `f64: std::hash::Hash` is not satisfied
+error[E0277]: the trait bound `f64: Hash` is not satisfied
    --> $DIR/not_eq_relation.rs:8:15
     |
 8   |     struct Ok(f64);
-    |               ^^^ the trait `std::hash::Hash` is not implemented for `f64`
+    |               ^^^ the trait `Hash` is not implemented for `f64`
     |
    ::: $RUST/core/src/hash/mod.rs
     |
@@ -11,15 +11,15 @@ error[E0277]: the trait bound `f64: std::hash::Hash` is not satisfied
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `f64: std::cmp::Eq` is not satisfied
+error[E0277]: the trait bound `f64: Eq` is not satisfied
    --> $DIR/not_eq_relation.rs:8:15
     |
 8   |     struct Ok(f64);
-    |               ^^^ the trait `std::cmp::Eq` is not implemented for `f64`
+    |               ^^^ the trait `Eq` is not implemented for `f64`
     |
    ::: $RUST/core/src/cmp.rs
     |
     | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-    |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+    |                               -- required by this bound in `AssertParamIsEq`
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
closes #4
supersedes #5

The parser now accepts visibility modifiers on struct declarations and
their fields inside the `crepe!` block.

Also attributes can be added on struct definitions, allowing custom derive
or other attributes to be associated to the types.

The attributes can be placed after an `@input` or `@output` modifier and
as usual before the struct declaration.