### PR TITLE
add support for lifetimes in relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add support for lifetimes in relations (#9)
+
 ## 0.1.3 - 2020-11-21
 
 - Add shorter syntax for defining fact-rules (#6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Add support for lifetimes in relations (#9)
+- Add support for lifetimes in relations and the `ref` keyword (#9)
+- Add benchmarks and support for custom hashers (#9)
 
 ## 0.1.3 - 2020-11-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,21 @@ edition = "2018"
 
 [lib]
 proc-macro = true
+bench = false
+
+[[bench]]
+name = "graph_walking"
+harness = false
+
+[[bench]]
+name = "fibonacci"
+harness = false
+
 
 [dev-dependencies]
 trybuild = "1.0"
+criterion = "0.3"
+fnv = "1.0"
 
 [dependencies]
 syn = { version = "1.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ closure for large graphs (~1000 nodes) run at comparable speed to compiled
 [Souffle](https://souffle-lang.github.io/), and at a fraction of the
 compilation time.
 
+For benchmarks, see the [`benches/` directory](benches/).
+The benchmarks can be run using `cargo bench`.
+
 This macro generates a `Crepe` struct in the current module, as well as structs
 for all of the declared relations. This means that to integrate Crepe inside a
 larger program, you should put it in its own module with related code. See the

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,0 +1,41 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use crepe::crepe;
+
+crepe! {
+    @input
+    struct Depth(u128);
+
+    @output
+    struct Fib(u128, u128);
+
+    Fib(0, 0) <- (true);
+    Fib(1, 1) <- (true);
+
+    Fib(n + 2, x + y) <-
+        Depth(depth),
+        Fib(n, x), Fib(n + 1, y), (n <= depth);
+}
+
+// Doesn't return the fibonacci number but instead the number of relations generated.
+fn fibonacci_length(n: u128) -> usize {
+    let mut rt = Crepe::new();
+
+    rt.extend(&[Depth(n)]);
+
+    let (fibs,) = rt.run_with_hasher::<fnv::FnvBuildHasher>();
+    fibs.len()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "fibonacci",
+        |b, n| {
+            b.iter(|| fibonacci_length(black_box(*n)));
+        },
+        vec![50, 100, 150],
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/graph_walking.rs
+++ b/benches/graph_walking.rs
@@ -1,0 +1,59 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use crepe::crepe;
+
+const MAX_PATH_LEN: u32 = 50;
+
+crepe! {
+    @input
+    struct Edge(i32, i32, u32);
+
+    @output
+    struct Walk(i32, i32, u32);
+
+    @output
+    struct NoWalk(i32, i32);
+
+    struct Node(i32);
+
+    Node(x) <- Edge(x, _, _);
+    Node(x) <- Edge(_, x, _);
+
+    Walk(x, x, 0) <- Node(x);
+    Walk(x, z, len1 + len2) <-
+        Edge(x, y, len1),
+        Walk(y, z, len2),
+        (len1 + len2 <= MAX_PATH_LEN);
+
+    NoWalk(x, y) <- Node(x), Node(y), !Walk(x, y, _);
+}
+
+fn walk(n: usize) -> (usize, usize) {
+    let n = n as i32;
+    let mut edges = Vec::new();
+    for i in 0..n {
+        for j in 0..n {
+            if i + j % 50 < 2 {
+                edges.push(Edge(i, j, 5));
+            }
+        }
+    }
+
+    let mut runtime = Crepe::new();
+    runtime.extend(edges);
+    let (walk, nowalk) = runtime.run_with_hasher::<fnv::FnvBuildHasher>();
+    (walk.len(), nowalk.len())
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "walk",
+        |b, input| {
+            b.iter(|| walk(black_box(*input)));
+        },
+        vec![128, 256, 512],
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ use strata::Strata;
 /// # Evaluation Mode
 /// All generated code uses semi-naive evaluation (see Chapter 3 of _Datalog
 /// and Recursive Query Processing_), and it is split into multiple strata to
-/// enable stratified negation. For example, we can extend the code above to
+/// enable stratified negation. For example, we can extend the first example to
 /// also compute the complement of transitive closure in a graph:
 /// ```
 /// mod datalog {
@@ -188,6 +188,34 @@ use strata::Strata;
 ///     }
 /// }
 /// # fn main() {}
+/// ```
+///
+/// # Lifetimes and Attributes
+/// This macro allows you to specify attributes, visibility modifiers, and
+/// lifetimes on the relation structs. These can include additional `derive`
+/// attributes, and lifetimes can be used to construct relations that include
+/// non-owning references. The following example computes suffixes of words.
+/// ```
+/// use crepe::crepe;
+///
+/// crepe! {
+///     @input
+///     struct Word<'a>(&'a str);
+///
+///     @output
+///     #[derive(Debug)]
+///     struct Suffix<'a>(&'a str);
+///
+///     Suffix(w) <- Word(w);
+///     Suffix(&w[1..]) <- Suffix(w), (!w.is_empty());
+/// }
+///
+/// fn main() {
+///     let mut runtime = Crepe::new();
+///     runtime.extend(&[Word("banana"), Word("bandana")]);
+///     let (suffixes,) = runtime.run();
+///     println!("{:?}", suffixes);
+/// }
 /// ```
 ///
 /// # Hygiene

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,7 +1,9 @@
 //! Parsing logic
 
 use syn::punctuated::Punctuated;
-use syn::{parenthesized, token, Attribute, Expr, ExprLet, Ident, Result, Token, Visibility};
+use syn::{
+    parenthesized, token, Attribute, Expr, ExprLet, Generics, Ident, Result, Token, Visibility,
+};
 use syn::{
     parse::{Parse, ParseStream},
     Field,
@@ -40,6 +42,7 @@ pub struct Relation {
     pub visibility: Visibility,
     pub struct_token: Token![struct],
     pub name: Ident,
+    pub generics: Generics,
     pub paren_token: token::Paren,
     pub fields: Punctuated<Field, Token![,]>,
     pub semi_token: Token![;],
@@ -61,6 +64,7 @@ impl Parse for Relation {
             visibility: input.parse()?,
             struct_token: input.parse()?,
             name: input.parse()?,
+            generics: input.parse()?,
             paren_token: parenthesized!(content in input),
             fields: content.parse_terminated(Field::parse_unnamed)?,
             semi_token: input.parse()?,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,6 @@
 //! Parsing logic
 
+use quote::ToTokens;
 use syn::punctuated::Punctuated;
 use syn::{
     parenthesized, token, Attribute, Expr, ExprLet, Generics, Ident, Result, Token, Visibility,
@@ -35,6 +36,13 @@ impl Parse for Program {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationType {
+    Input,
+    Intermediate,
+    Output,
+}
+
 #[derive(Clone)]
 pub struct Relation {
     pub attribute: Option<Ident>,
@@ -46,6 +54,22 @@ pub struct Relation {
     pub paren_token: token::Paren,
     pub fields: Punctuated<Field, Token![,]>,
     pub semi_token: Token![;],
+}
+
+impl Relation {
+    pub fn relation_type(&self) -> std::result::Result<RelationType, &Ident> {
+        if let Some(attr) = &self.attribute {
+            if attr == "input" {
+                Ok(RelationType::Input)
+            } else if attr == "output" {
+                Ok(RelationType::Output)
+            } else {
+                Err(attr)
+            }
+        } else {
+            Ok(RelationType::Intermediate)
+        }
+    }
 }
 
 impl Parse for Relation {
@@ -137,7 +161,7 @@ pub struct Fact {
     pub negate: Option<Token![!]>,
     pub relation: Ident,
     pub paren_token: token::Paren,
-    pub fields: Punctuated<Option<Expr>, Token![,]>,
+    pub fields: Punctuated<FactField, Token![,]>,
 }
 
 impl Parse for Fact {
@@ -150,12 +174,32 @@ impl Parse for Fact {
             paren_token: parenthesized!(content in input),
             fields: content.parse_terminated(|input| {
                 if input.peek(Token![_]) {
-                    let _: Token![_] = input.parse()?;
-                    Ok(None)
+                    Ok(FactField::Ignored(input.parse()?))
+                } else if input.peek(Token![ref]) {
+                    let ref_tok: Token![ref] = input.parse()?;
+                    let ident: Ident = input.parse()?;
+                    Ok(FactField::Ref(ref_tok, ident))
                 } else {
-                    input.parse().map(Some)
+                    Ok(FactField::Expr(input.parse()?))
                 }
             })?,
         })
+    }
+}
+
+#[derive(Clone)]
+pub enum FactField {
+    Ignored(syn::Token![_]),
+    Ref(syn::Token![ref], syn::Ident),
+    Expr(Box<syn::Expr>),
+}
+
+impl ToTokens for FactField {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            FactField::Ignored(t) => tokens.extend(quote::quote! { #t }),
+            FactField::Ref(ref_tok, ident) => tokens.extend(quote::quote! { #ref_tok #ident }),
+            FactField::Expr(expr) => tokens.extend(quote::quote! { #expr }),
+        }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,13 +1,11 @@
 //! Parsing logic
 
-use quote::ToTokens;
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{
-    parenthesized, token, Attribute, Expr, ExprLet, Generics, Ident, Result, Token, Visibility,
-};
-use syn::{
-    parse::{Parse, ParseStream},
-    Field,
+    parenthesized, parse_quote, token, Attribute, Expr, ExprLet, Field, Generics, Ident, Result,
+    Token, Visibility,
 };
 
 #[derive(Clone)]
@@ -114,8 +112,8 @@ impl Parse for Rule {
         if lookahead.peek(Token![;]) {
             let semi_token = input.parse()?;
 
-            let arrow_token = syn::parse_quote!(<-);
-            let clauses = syn::parse_quote!((true));
+            let arrow_token = parse_quote!(<-);
+            let clauses = parse_quote!((true));
 
             Ok(Self {
                 goal,
@@ -189,17 +187,17 @@ impl Parse for Fact {
 
 #[derive(Clone)]
 pub enum FactField {
-    Ignored(syn::Token![_]),
-    Ref(syn::Token![ref], syn::Ident),
-    Expr(Box<syn::Expr>),
+    Ignored(Token![_]),
+    Ref(Token![ref], Ident),
+    Expr(Box<Expr>),
 }
 
 impl ToTokens for FactField {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         match self {
-            FactField::Ignored(t) => tokens.extend(quote::quote! { #t }),
-            FactField::Ref(ref_tok, ident) => tokens.extend(quote::quote! { #ref_tok #ident }),
-            FactField::Expr(expr) => tokens.extend(quote::quote! { #expr }),
+            FactField::Ignored(t) => tokens.extend(quote! { #t }),
+            FactField::Ref(ref_tok, ident) => tokens.extend(quote! { #ref_tok #ident }),
+            FactField::Expr(expr) => tokens.extend(quote! { #expr }),
         }
     }
 }

--- a/tests/test_intermediate_lifetime.rs
+++ b/tests/test_intermediate_lifetime.rs
@@ -1,0 +1,30 @@
+// This test uses input values by reference inside an intermediate relation
+// and copies it into the output relation.
+// Binding with `ref name` captures a value by reference.
+
+use crepe::crepe;
+
+crepe! {
+    @input
+    struct Input([usize; 4]);
+
+    struct Value<'a>(&'a usize);
+
+    @output
+    struct Output(usize);
+
+    Value(&x[0]) <- Input(ref x);
+    Value(&x[2]) <- Input(ref x);
+
+    Output(*x) <- Value(x);
+}
+
+#[test]
+fn test_intermediate_lifetime() {
+    let mut rt = Crepe::new();
+    rt.extend(&[Input([0, 1, 2, 3]), Input([1, 2, 3, 4])]);
+    let (res,) = rt.run();
+    let mut res = res.into_iter().map(|Output(n)| n).collect::<Vec<_>>();
+    res.sort_unstable();
+    assert_eq!(res, [0, 1, 2, 3]);
+}

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -20,12 +20,14 @@ mod datalog {
         @input
         struct Borrowed<'a>(&'a str);
 
-        struct Test<'a>(&'a u64);
+        struct Test<'a>(&'a i32);
 
         Tc(x, y) <- Edge(x, y);
         Tc(x, z) <- Edge(x, y), Tc(y, z), (z > 5);
 
         Tc(x, y) <- let (x, y) = (3, 4);
+
+        Test(x) <- Edge(ref x, _);
 
         Intermediate(_x, crepe, z) <- (true), (false), Intermediate(_x, crepe, z);
         Intermediate(42, y, 'c') <- (true), (false), Intermediate(_x, y, _z);

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -17,6 +17,11 @@ mod datalog {
         struct Intermediate(i32, u64, char);
         struct Unit();
 
+        @input
+        struct Borrowed<'a>(&'a str);
+
+        struct Test<'a>(&'a u64);
+
         Tc(x, y) <- Edge(x, y);
         Tc(x, z) <- Edge(x, y), Tc(y, z), (z > 5);
 

--- a/tests/test_ref_overwrite.rs
+++ b/tests/test_ref_overwrite.rs
@@ -1,0 +1,27 @@
+// This test ensures that variables bound with `ref` are always bound,
+// overwriting previous variables of the same name.
+//
+// Behavior may change in the future, since this is an edge case.
+
+use crepe::crepe;
+
+crepe! {
+    @input
+    struct Input(i32);
+
+    @output
+    #[derive(Debug, Ord, PartialOrd)]
+    struct Output(i32);
+
+    Output(*_x + *_x) <- Input(_x), Input(ref _x);
+}
+
+#[test]
+fn test_ref_overwrite() {
+    let mut rt = Crepe::new();
+    rt.extend(&[Input(2), Input(3)]);
+    let (res,) = rt.run();
+    let mut res: Vec<_> = res.into_iter().collect();
+    res.sort_unstable();
+    assert_eq!(res, vec![Output(4), Output(6)]);
+}

--- a/tests/test_transitive_closure.rs
+++ b/tests/test_transitive_closure.rs
@@ -24,6 +24,28 @@ mod datalog {
     }
 }
 
+mod datalog_clauses_swapped {
+    use crepe::crepe;
+
+    crepe! {
+        @input
+        struct Edge(i32, i32);
+
+        @output
+        struct Tc(i32, i32);
+
+        Tc(x, y) <- Edge(x, y);
+        Tc(x, z) <- Tc(y, z), Edge(x, y);
+    }
+
+    pub fn run(edges: &[(i32, i32)]) -> Vec<(i32, i32)> {
+        let mut runtime = Crepe::new();
+        runtime.extend(edges.iter().map(|&(a, b)| Edge(a, b)));
+        let (tc,) = runtime.run();
+        tc.into_iter().map(|Tc(a, b)| (a, b)).collect()
+    }
+}
+
 #[test]
 fn test_transitive_closure() {
     let edges = vec![(1, 2), (2, 3), (3, 4), (2, 5)];
@@ -38,8 +60,33 @@ fn test_transitive_closure() {
         (3, 4),
     ];
     let mut result = datalog::run(&edges);
-    result.sort();
+    result.sort_unstable();
     assert_eq!(result, expected);
+}
+
+// make sure that clauses can be swapped and still get the same result.
+#[test]
+fn test_transitive_closure_same_as_with_clauses_swapped() {
+    let edges = vec![(1, 2), (2, 3), (3, 4), (2, 5)];
+    let expected = vec![
+        (1, 2),
+        (1, 3),
+        (1, 4),
+        (1, 5),
+        (2, 3),
+        (2, 4),
+        (2, 5),
+        (3, 4),
+    ];
+    let mut result_a = datalog::run(&edges);
+    result_a.sort_unstable();
+    assert_eq!(result_a, expected);
+
+    let mut result_b = datalog_clauses_swapped::run(&edges);
+    result_b.sort_unstable();
+    assert_eq!(result_b, expected);
+
+    assert_eq!(result_a, result_b);
 }
 
 // Version of the above test with &'a str
@@ -77,6 +124,6 @@ fn test_transitive_closure_str() {
         ("world", "foo"),
     ];
     let mut result = datalog_str::run(&edges);
-    result.sort();
+    result.sort_unstable();
     assert_eq!(result, expected);
 }

--- a/tests/test_transitive_closure.rs
+++ b/tests/test_transitive_closure.rs
@@ -42,7 +42,7 @@ fn test_transitive_closure() {
     assert_eq!(result, expected);
 }
 
-// Version of the above test with &'static str
+// Version of the above test with &'a str
 
 mod datalog_str {
     use crepe::crepe;

--- a/tests/test_transitive_closure.rs
+++ b/tests/test_transitive_closure.rs
@@ -49,16 +49,16 @@ mod datalog_str {
 
     crepe! {
         @input
-        struct Edge(&'static str, &'static str);
+        struct Edge<'a>(&'a str, &'a str);
 
         @output
-        struct Tc(&'static str, &'static str);
+        struct Tc<'a>(&'a str, &'a str);
 
         Tc(x, y) <- Edge(x, y);
         Tc(x, z) <- Edge(x, y), Tc(y, z);
     }
 
-    pub fn run(edges: &[(&'static str, &'static str)]) -> Vec<(&'static str, &'static str)> {
+    pub fn run<'a>(edges: &[(&'a str, &'a str)]) -> Vec<(&'a str, &'a str)> {
         let mut runtime = Crepe::new();
         runtime.extend(edges.iter().map(|&(a, b)| Edge(a, b)));
         let (tc,) = runtime.run();

--- a/tests/ui/non_input_lifetime.rs
+++ b/tests/ui/non_input_lifetime.rs
@@ -1,0 +1,20 @@
+// In this test, the relation `Out` refers to data inside the `In` relation by
+// taking a reference to its contents.
+// Since that lifetime is related to input data which is moved and consumed
+// within the `run(self)` function, the reference would out-live it's lifetime.
+
+mod datalog {
+    use crepe::crepe;
+
+    crepe! {
+        @input
+        struct Input(u32, u32);
+
+        @output
+        struct Output<'a>(&'a u32);
+
+        Output(&a) <- Input(a, _);
+    }
+}
+
+fn main() {}

--- a/tests/ui/non_input_lifetime.stderr
+++ b/tests/ui/non_input_lifetime.stderr
@@ -1,0 +1,5 @@
+error: Lifetime on output relation without any input relations having a lifetime
+  --> $DIR/non_input_lifetime.rs:14:22
+   |
+14 |         struct Output<'a>(&'a u32);
+   |                      ^^^^

--- a/tests/ui/underscore_in_goal.stderr
+++ b/tests/ui/underscore_in_goal.stderr
@@ -1,5 +1,5 @@
 error: Cannot have _ in goal atom of rule.
- --> $DIR/underscore_in_goal.rs:7:5
+ --> $DIR/underscore_in_goal.rs:7:8
   |
 7 |     Ok(_) <- Ok(_);
-  |     ^^
+  |        ^


### PR DESCRIPTION
closes #2

Input relations, output relations and intermediate relations
can all have one or more lifetime parameters.

If an input relation has a lifetime parameter, the whole
`Crepe` type will have a single lifetime parameter and all lifetimes of input relations will use that lifetime (e.g. `Type<'a, 'b>` will only be used as `Type<'a, 'a>`).