### PR TITLE
add initial benchmarks using criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,18 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[[bench]]
+name = "graph_walking"
+harness = false
+
+[[bench]]
+name = "fibonacci"
+harness = false
+
+
 [dev-dependencies]
 trybuild = "1.0"
+criterion = "0.3"
 
 [dependencies]
 syn = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ harness = false
 [dev-dependencies]
 trybuild = "1.0"
 criterion = "0.3"
+fnv = "1.0"
 
 [dependencies]
 syn = { version = "1.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ closure for large graphs (~1000 nodes) run at comparable speed to compiled
 [Souffle](https://souffle-lang.github.io/), and at a fraction of the
 compilation time.
 
+For benchmarks, see the [`benches/` directory](benches/).
+The benchmarks can be run using `cargo bench`.
+
 This macro generates a `Crepe` struct in the current module, as well as structs
 for all of the declared relations. This means that to integrate Crepe inside a
 larger program, you should put it in its own module with related code. See the

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,0 +1,41 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use crepe::crepe;
+
+crepe! {
+    @input
+    struct Depth(u128);
+
+    @output
+    struct Fib(u128, u128);
+
+    Fib(0, 0) <- (true);
+    Fib(1, 1) <- (true);
+
+    Fib(n + 2, x + y) <-
+        Depth(depth),
+        Fib(n, x), Fib(n + 1, y), (n <= depth);
+}
+
+// Doesn't return the fibonacci number but instead the number of relations generated.
+fn fibonacci_length(n: u128) -> usize {
+    let mut rt = Crepe::new();
+
+    rt.extend(&[Depth(n)]);
+
+    let (fibs,) = rt.run();
+    fibs.len()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "fibonacci",
+        |b, n| {
+            b.iter(|| fibonacci_length(black_box(*n)));
+        },
+        vec![50, 100, 150],
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -23,7 +23,7 @@ fn fibonacci_length(n: u128) -> usize {
 
     rt.extend(&[Depth(n)]);
 
-    let (fibs,) = rt.run();
+    let (fibs,) = rt.run_with_hasher::<fnv::FnvBuildHasher>();
     fibs.len()
 }
 

--- a/benches/graph_walking.rs
+++ b/benches/graph_walking.rs
@@ -41,7 +41,7 @@ fn walk(n: usize) -> (usize, usize) {
 
     let mut runtime = Crepe::new();
     runtime.extend(edges);
-    let (walk, nowalk) = runtime.run();
+    let (walk, nowalk) = runtime.run_with_hasher::<fnv::FnvBuildHasher>();
     (walk.len(), nowalk.len())
 }
 

--- a/benches/graph_walking.rs
+++ b/benches/graph_walking.rs
@@ -1,0 +1,59 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use crepe::crepe;
+
+const MAX_PATH_LEN: u32 = 50;
+
+crepe! {
+    @input
+    struct Edge(i32, i32, u32);
+
+    @output
+    struct Walk(i32, i32, u32);
+
+    @output
+    struct NoWalk(i32, i32);
+
+    struct Node(i32);
+
+    Node(x) <- Edge(x, _, _);
+    Node(x) <- Edge(_, x, _);
+
+    Walk(x, x, 0) <- Node(x);
+    Walk(x, z, len1 + len2) <-
+        Edge(x, y, len1),
+        Walk(y, z, len2),
+        (len1 + len2 <= MAX_PATH_LEN);
+
+    NoWalk(x, y) <- Node(x), Node(y), !Walk(x, y, _);
+}
+
+fn walk(n: usize) -> (usize, usize) {
+    let n = n as i32;
+    let mut edges = Vec::new();
+    for i in 0..n {
+        for j in 0..n {
+            if i + j % 50 < 2 {
+                edges.push(Edge(i, j, 5));
+            }
+        }
+    }
+
+    let mut runtime = Crepe::new();
+    runtime.extend(edges);
+    let (walk, nowalk) = runtime.run();
+    (walk.len(), nowalk.len())
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "walk",
+        |b, input| {
+            b.iter(|| walk(black_box(*input)));
+        },
+        vec![128, 256, 512],
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,16 +542,16 @@ fn make_extend(context: &Context) -> proc_macro2::TokenStream {
 ///
 /// Here's an example of what might be generated for transitive closure:
 /// ```ignore
-/// fn run(self) -> (::std::collections::HashSet<Tc>,) {
+/// fn run_with_hasher<S: BuildHasher + Default>(self) -> (::std::collections::HashSet<Tc, S>,) {
 ///     // Relations
-///     let mut __edge: ::std::collections::HashSet<Edge> = ::std::collections::HashSet::new();
-///     let mut __edge_update: ::std::collections::HashSet<Edge> = ::std::collections::HashSet::new();
-///     let mut __tc: ::std::collections::HashSet<Tc> = ::std::collections::HashSet::new();
-///     let mut __tc_update: ::std::collections::HashSet<Tc> = ::std::collections::HashSet::new();
+///     let mut __edge: ::std::collections::HashSet<Edge, S> = ::std::collections::HashSet::default();
+///     let mut __edge_update: ::std::collections::HashSet<Edge, S> = ::std::collections::HashSet::default();
+///     let mut __tc: ::std::collections::HashSet<Tc, S> = ::std::collections::HashSet::default();
+///     let mut __tc_update: ::std::collections::HashSet<Tc, S> = ::std::collections::HashSet::default();
 ///
 ///     // Indices
-///     let mut __tc_index_bf: ::std::collections::HashMap<(i32,), ::std::vec::Vec<Tc>> =
-///         ::std::collections::HashMap::new();
+///     let mut __tc_index_bf: ::std::collections::HashMap<(i32,), ::std::vec::Vec<Tc>, S> =
+///         ::std::collections::HashMap::default();
 ///
 ///     // Input relations
 ///     __edge_update.extend(self.edge);
@@ -565,8 +565,8 @@ fn make_extend(context: &Context) -> proc_macro2::TokenStream {
 ///         }
 ///         __edge.extend(&__edge_update);
 ///
-///         let mut __tc_new: ::std::collections::HashSet<Tc> = ::std::collections::HashSet::new();
-///         let mut __edge_new: ::std::collections::HashSet<Tc> = ::std::collections::HashSet::new();
+///         let mut __tc_new: ::std::collections::HashSet<Tc, S> = ::std::collections::HashSet::default();
+///         let mut __edge_new: ::std::collections::HashSet<Tc, S> = ::std::collections::HashSet::default();
 ///
 ///         for &__crepe_var_0 in __edge.iter() {
 ///             let x = __crepe_var_0.0;
@@ -624,10 +624,10 @@ fn make_run(context: &Context) -> proc_macro2::TokenStream {
             let var = format_ident!("__{}", lower);
             let var_update = format_ident!("__{}_update", lower);
             quote! {
-                let mut #var: ::std::collections::HashSet<#name> =
-                    ::std::collections::HashSet::new();
-                let mut #var_update: ::std::collections::HashSet<#name> =
-                    ::std::collections::HashSet::new();
+                let mut #var: ::std::collections::HashSet<#name, S> =
+                    ::std::collections::HashSet::default();
+                let mut #var_update: ::std::collections::HashSet<#name, S> =
+                    ::std::collections::HashSet::default();
             }
         });
         let init_indices = indices.iter().map(|index| {
@@ -639,8 +639,8 @@ fn make_run(context: &Context) -> proc_macro2::TokenStream {
             let key_type = index.key_type(context);
             quote! {
                 let mut #index_name:
-                    ::std::collections::HashMap<(#(#key_type,)*), ::std::vec::Vec<#rel_name>> =
-                    ::std::collections::HashMap::new();
+                    ::std::collections::HashMap<(#(#key_type,)*), ::std::vec::Vec<#rel_name>, S> =
+                    ::std::collections::HashMap::default();
             }
         });
         let load_inputs = context.rels_input.values().map(|rel| {
@@ -666,12 +666,17 @@ fn make_run(context: &Context) -> proc_macro2::TokenStream {
         }
     };
 
-    let output_ty = make_output_ty(&context);
+    let output_ty_hasher = make_output_ty(&context, quote! { S });
+    let output_ty_default = make_output_ty(&context, quote! {});
     quote! {
-        fn run(self) -> #output_ty {
+        fn run_with_hasher<S: ::std::hash::BuildHasher + Default>(self) -> #output_ty_hasher {
             #initialize
             #main_loops
             #output
+        }
+
+        fn run(self) -> #output_ty_default {
+            self.run_with_hasher::<::std::collections::hash_map::RandomState>()
         }
     }
 }
@@ -710,8 +715,8 @@ fn make_stratum(
             let lower = to_lowercase(name);
             let rel_new = format_ident!("__{}_new", lower);
             quote! {
-                let mut #rel_new: ::std::collections::HashSet<#name> =
-                    ::std::collections::HashSet::new();
+                let mut #rel_new: ::std::collections::HashSet<#name, S> =
+                    ::std::collections::HashSet::default();
             }
         })
         .collect();
@@ -778,8 +783,8 @@ fn make_updates(
         let bound_pos = index.bound_pos();
         Some(quote! {
             let mut #index_name_update:
-                ::std::collections::HashMap<(#(#key_type,)*), ::std::vec::Vec<#rel_name>> =
-                ::std::collections::HashMap::new();
+                ::std::collections::HashMap<(#(#key_type,)*), ::std::vec::Vec<#rel_name>, S> =
+                ::std::collections::HashMap::default();
             for &__crepe_var in #rel_update.iter() {
                 #index_name
                     .entry((#(__crepe_var.#bound_pos,)*))
@@ -984,10 +989,10 @@ fn make_clause(
     }
 }
 
-fn make_output_ty(context: &Context) -> proc_macro2::TokenStream {
+fn make_output_ty(context: &Context, hasher: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let fields = &context.output_order;
     quote! {
-        (#(::std::collections::HashSet<#fields>,)*)
+        (#(::std::collections::HashSet<#fields, #hasher>,)*)
     }
 }
 

--- a/tests/ui/not_eq_relation.stderr
+++ b/tests/ui/not_eq_relation.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `f64: std::hash::Hash` is not satisfied
+error[E0277]: the trait bound `f64: Hash` is not satisfied
    --> $DIR/not_eq_relation.rs:8:15
     |
 8   |     struct Ok(f64);
-    |               ^^^ the trait `std::hash::Hash` is not implemented for `f64`
+    |               ^^^ the trait `Hash` is not implemented for `f64`
     |
    ::: $RUST/core/src/hash/mod.rs
     |
@@ -11,15 +11,15 @@ error[E0277]: the trait bound `f64: std::hash::Hash` is not satisfied
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `f64: std::cmp::Eq` is not satisfied
+error[E0277]: the trait bound `f64: Eq` is not satisfied
    --> $DIR/not_eq_relation.rs:8:15
     |
 8   |     struct Ok(f64);
-    |               ^^^ the trait `std::cmp::Eq` is not implemented for `f64`
+    |               ^^^ the trait `Eq` is not implemented for `f64`
     |
    ::: $RUST/core/src/cmp.rs
     |
     | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-    |                               -- required by this bound in `std::cmp::AssertParamIsEq`
+    |                               -- required by this bound in `AssertParamIsEq`
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR adds two benchmarks:
- `graph_walking`: uses a modified version of the graph walking example in the README. The main modification is that the generation of input facts doesn't use `rand` any more in order to keep the inputs the same
- `fibonacci` uses the code from the Fibonacci test case and adds a configurable `n` parameter, also increasing the width of the number type