### PR TITLE
Minimize and speed up the Collatz conjecture bench

### DIFF
--- a/benches/collatz.rs
+++ b/benches/collatz.rs
@@ -6,15 +6,12 @@ crepe! {
     @input
     struct Start(u128);
 
-    struct Intermediate(u128, u128);
-
     @output
     struct Col(u128);
 
-    Intermediate(0, n) <- Start(n);
-    Intermediate(n + 1, if x % 2 == 0 { x / 2 } else { 3 * x + 1 }) <- Intermediate(n, x), (x != 1);
-
-    Col(n) <- Intermediate(n, x), (x != 1);
+    Col(x) <- Start(x);
+    Col(x / 2) <- Col(x), (x % 2 == 0);
+    Col(3 * x + 1) <- Col(x), (x % 2 != 0), (x != 1);
 }
 
 // Return the stopping time for the given starting number.
@@ -24,7 +21,7 @@ fn collatz_length(n: u128) -> usize {
     rt.extend(&[Start(n)]);
 
     let (cols,) = rt.run_with_hasher::<fnv::FnvBuildHasher>();
-    cols.len()
+    cols.len() - 1
 }
 
 fn criterion_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
Now that I've had a bit more time to tinker with `crepe`, I was able to minimize the Collatz conjecture benchmark which, in my opinion, makes it a lot more clear. This also made it a lot faster:
```
collatz/9               time:   [2.2401 us 2.2420 us 2.2440 us]                       
                        change: [-50.991% -50.896% -50.813%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe
collatz/77031           time:   [37.722 us 37.743 us 37.765 us]                           
                        change: [-47.089% -46.975% -46.839%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
collatz/9780657630      time:   [125.33 us 125.67 us 125.96 us]                               
                        change: [-50.623% -50.390% -50.161%] (p = 0.00 < 0.05)
                        Performance has improved.
```