### PR TITLE
Fix typo in graph walk benchmark

### DIFF
--- a/benches/graph_walking.rs
+++ b/benches/graph_walking.rs
@@ -33,7 +33,7 @@ fn walk(n: usize) -> (usize, usize) {
     let mut edges = Vec::new();
     for i in 0..n {
         for j in 0..n {
-            if i + j % 50 < 2 {
+            if (i + j) % 50 < 2 {
                 edges.push(Edge(i, j, 5));
             }
         }


### PR DESCRIPTION
This was messing up the benchmark a lot!